### PR TITLE
Switch command line option from index to friendlyName

### DIFF
--- a/EndPointController/EndPointController.cpp
+++ b/EndPointController/EndPointController.cpp
@@ -66,7 +66,7 @@ int _tmain(int argc, _TCHAR* argv[])
 									{
 										// if no options, print the device
 										// otherwise, find the selected device and set it to be default
-										if (argc != 2) printf("Audio Device %d: %ws\n", i, friendlyName.pwszVal);
+										if (argc != 2) printf("Audio Device %d: \"%ws\"\n", i, friendlyName.pwszVal);
 										else if (_tcscmp(friendlyName.pwszVal, argv[1]) == 0) SetDefaultAudioPlaybackDevice(wstrID);
 										PropVariantClear(&friendlyName);
 									}

--- a/EndPointController/EndPointController.cpp
+++ b/EndPointController/EndPointController.cpp
@@ -27,10 +27,6 @@ HRESULT SetDefaultAudioPlaybackDevice(LPCWSTR devID)
 // EndPointController.exe [NewDefaultDeviceID]
 int _tmain(int argc, _TCHAR* argv[])
 {
-	// read the command line option, -1 indicates list devices.
-	int option = -1;
-	if (argc == 2) option = atoi((char*)argv[1]);
-
 	HRESULT hr = CoInitialize(NULL);
 	if (SUCCEEDED(hr))
 	{
@@ -70,8 +66,8 @@ int _tmain(int argc, _TCHAR* argv[])
 									{
 										// if no options, print the device
 										// otherwise, find the selected device and set it to be default
-										if (option == -1) printf("Audio Device %d: %ws\n",i, friendlyName.pwszVal);
-										if (i == option) SetDefaultAudioPlaybackDevice(wstrID);
+										if (argc != 2) printf("Audio Device %d: %ws\n", i, friendlyName.pwszVal);
+										else if (_tcscmp(friendlyName.pwszVal, argv[1]) == 0) SetDefaultAudioPlaybackDevice(wstrID);
 										PropVariantClear(&friendlyName);
 									}
 									pStore->Release();

--- a/EndPointController/EndPointController.vcxproj
+++ b/EndPointController/EndPointController.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -20,12 +20,14 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -45,7 +47,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/EndPointController/EndPointController.vcxproj
+++ b/EndPointController/EndPointController.vcxproj
@@ -20,14 +20,16 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
+    <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
+    <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
When adding/removing devices or upgrading Windows, the numeric indices change. The alphanumeric friendlyName is a more robust parameter that can even be renamed by the user.
